### PR TITLE
feat: add nix build and deployment

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,120 @@
+{
+  "nodes": {
+    "colmena": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "stable": "stable"
+      },
+      "locked": {
+        "lastModified": 1762034856,
+        "narHash": "sha256-QVey3iP3UEoiFVXgypyjTvCrsIlA4ecx6Acaz5C8/PQ=",
+        "owner": "zhaofengli",
+        "repo": "colmena",
+        "rev": "349b035a5027f23d88eeb3bc41085d7ee29f18ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "colmena",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "colmena",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "colmena": "colmena",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "stable": {
+      "locked": {
+        "lastModified": 1750133334,
+        "narHash": "sha256-urV51uWH7fVnhIvsZIELIYalMYsyr2FCalvlRTzqWRw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "36ab78dab7da2e4e27911007033713bab534187b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Print Bot NixOS deployment with Colmena";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    colmena = {
+      url = "github:zhaofengli/colmena";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, colmena, ... }:
+  {
+    colmena = import ./hive.nix;
+
+    nixosConfigurations.rpi4 = nixpkgs.lib.nixosSystem {
+      system = "aarch64-linux";
+      modules = [ ./hosts/rpi4.nix ];
+    };
+
+    nixosConfigurations.vm = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [ ./vm.nix ];
+    };
+  };
+}

--- a/nix/hive.nix
+++ b/nix/hive.nix
@@ -1,0 +1,67 @@
+let
+  nodeName = "rpi4";
+in
+{
+  meta = {
+    nixpkgs = import (builtins.fetchGit {
+      name = "nixos-24.11-2025-01-15";
+      url = "https://github.com/NixOS/nixpkgs";
+      ref = "refs/heads/nixos-24.11";
+    }) {};
+  };
+
+  ${nodeName} = { lib, name, ... }: let
+    secretsFile = ./secrets/secrets.nix;
+    secrets = if builtins.pathExists secretsFile then import secretsFile else {};
+    get = path: lib.attrByPath path null secrets;
+  in {
+    imports = [ ./hosts/rpi4.nix ];
+
+    deployment = {
+      targetHost = lib.mkForce (get [ "hosts" name "sshHost" ]);
+      targetUser = lib.mkForce (get [ "hosts" name "sshUser" ]);
+      buildOnTarget = true;
+
+      keys = {
+        "bot-env" = {
+          text = get [ "hosts" name "botEnv" ];
+          destDir = "/run/keys";
+          permissions = "0640";
+          group = "print-bot";
+        };
+      };
+    };
+
+    users.users.print-bot-user.openssh.authorizedKeys.keys = [
+      (get [ "hosts" name "sshKey" ])
+    ];
+
+    hardware.printers = {
+      ensureDefaultPrinter = "td-printer";
+      ensurePrinters = [{
+        name = "td-printer";
+        description = "HP LaserJet M207-M212";
+        deviceUri = get [ "hosts" name "printerUri" ];
+        model = "everywhere";
+      }];
+    };
+
+    services.dnsmasq.settings.dhcp-host =
+      "${get [ "hosts" name "printerMac" ]},td-printer,10.30.30.66";
+
+    networking.wireless = {
+      enable = true;
+      networks.${get [ "hosts" name "wifiSSID" ]}.psk = get [ "hosts" name "wifiPassword" ];
+      interfaces = [ "wlan0" ];
+    };
+
+    assertions = [
+      {
+        assertion = get [ "hosts" name "sshHost" ] != null;
+        message = "Missing sshHost for '${name}'. Create secrets/secrets.nix";
+      }
+    ];
+
+    nixpkgs.system = "aarch64-linux";
+  };
+}

--- a/nix/hosts/rpi4.nix
+++ b/nix/hosts/rpi4.nix
@@ -1,0 +1,104 @@
+{ config, pkgs, lib, ... }:
+
+{
+  imports = [ ../modules/print-bot.nix ];
+
+  # Boot configuration for Raspberry Pi 4
+  boot = {
+    kernelPackages = pkgs.linuxKernel.packages.linux_rpi4;
+    initrd.availableKernelModules = [ "xhci_pci" "usbhid" "usb_storage" ];
+    loader = {
+      grub.enable = false;
+      generic-extlinux-compatible.enable = true;
+    };
+    extraModprobeConfig = "options cfg80211 ieee80211_regdom=PL";
+  };
+
+  # Filesystem
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/NIXOS_SD";
+    fsType = "ext4";
+    options = [ "noatime" ];
+  };
+
+  # Networking
+  networking = {
+    hostName = "print-bot";
+    nameservers = [ "8.8.8.8" "1.1.1.1" ];
+    interfaces.eth0.ipv4.addresses = [{
+      address = "10.30.30.30";
+      prefixLength = 24;
+    }];
+    firewall.interfaces.eth0.allowedUDPPorts = [ 67 68 ];
+  };
+
+  # Print Bot service
+  services.print-bot = {
+    enable = true;
+    secretsFile = "/run/keys/bot-env";
+  };
+
+  # DHCP server on eth0 for the printer
+  services.dnsmasq = {
+    enable = true;
+    settings = {
+      interface = "eth0";
+      bind-interfaces = true;
+      dhcp-range = "10.30.30.100,10.30.30.200,24h";
+      dhcp-option = [ "option:router,10.30.30.30" ];
+    };
+  };
+
+  # CUPS printing
+  services.printing = {
+    enable = true;
+    listenAddresses = [ "*:631" ];
+    allowFrom = [ "all" ];
+    browsing = true;
+    defaultShared = true;
+    openFirewall = true;
+    extraConf = "ServerAlias *";
+  };
+
+  # System services
+  services = {
+    openssh = {
+      enable = true;
+      settings.PasswordAuthentication = false;
+    };
+    tailscale = {
+      enable = true;
+      useRoutingFeatures = "both";
+    };
+  };
+
+  # User configuration
+  users = {
+    mutableUsers = false;
+    users.print-bot-user = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" "lp" ];
+    };
+  };
+
+  # Auto-login on console
+  services.getty.autologinUser = "print-bot-user";
+
+  # Packages
+  environment.systemPackages = with pkgs; [
+    vim
+    htop
+    git
+  ];
+
+  # Hardware
+  hardware.enableRedistributableFirmware = true;
+
+  # Passwordless sudo for wheel group (needed for Colmena deployments)
+  security.sudo.wheelNeedsPassword = false;
+
+  # Nix settings
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  system.stateVersion = "23.11";
+}

--- a/nix/modules/print-bot.nix
+++ b/nix/modules/print-bot.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.print-bot;
+
+  print-bot = pkgs.callPackage ../pkgs/print-bot.nix { };
+in {
+  options.services.print-bot = {
+    enable = lib.mkEnableOption "Print Bot service";
+
+    secretsFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to environment file containing TELOXIDE_TOKEN and ADMIN_GROUP_ID";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/print-bot";
+      description = "Directory for storing uploaded PDFs";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "print-bot";
+      description = "User to run the service as";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "print-bot";
+      description = "Group to run the service as";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = lib.mkIf (cfg.user == "print-bot") {
+      isSystemUser = true;
+      group = cfg.group;
+      extraGroups = [ "lp" "keys" ];
+    };
+
+    users.groups.${cfg.group} = lib.mkIf (cfg.group == "print-bot") { };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/uploads 0755 ${cfg.user} ${cfg.group} -"
+    ];
+
+    systemd.services.print-bot = {
+      description = "Print Bot";
+      after = [ "network-online.target" "cups.service" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.poppler_utils pkgs.cups ];
+
+      environment = {
+        RUST_LOG = "info";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        ExecStart = "${print-bot}/bin/rust_test_bot";
+        EnvironmentFile = cfg.secretsFile;
+        Restart = "always";
+        RestartSec = 5;
+
+        # Hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+        PrivateTmp = true;
+        SupplementaryGroups = [ "lp" ];
+      };
+    };
+  };
+}

--- a/nix/pkgs/print-bot.nix
+++ b/nix/pkgs/print-bot.nix
@@ -1,0 +1,29 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "print-bot";
+  version = "dev";
+
+  src = fetchFromGitHub {
+    owner = "technodzik-hackerspace";
+    repo = "print-bot";
+    rev = "842d10feb7b860039bd04635a7be85b0f9dbe954";
+    sha256 = "0l9ygbgk5w557958dpjv3cjri198c0954a9pmgxdmw74yl604425";
+  };
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoHash = "sha256-vQMFA1LGAsWJgVnntqxcHNaC0kA2CDIWDYsYxHUyOfM=";
+
+  meta = with lib; {
+    description = "Telegram printer bot";
+    homepage = "https://github.com/technodzik-hackerspace/print-bot";
+    mainProgram = "rust_test_bot";
+  };
+}

--- a/nix/secrets/.gitignore
+++ b/nix/secrets/.gitignore
@@ -1,0 +1,1 @@
+secrets.nix

--- a/nix/secrets/secrets.nix.example
+++ b/nix/secrets/secrets.nix.example
@@ -1,0 +1,19 @@
+# Deployment secrets
+# Copy to secrets.nix and fill in your values
+{
+  hosts = {
+    rpi4 = {
+      sshHost = "hostname.tailnet.ts.net";
+      sshUser = "username";
+      sshKey = "ssh-ed25519 AAAA... user@host";
+      botEnv = ''
+        TELOXIDE_TOKEN=YOUR_BOT_TOKEN
+        ADMIN_GROUP_ID=-1234567890
+      '';
+      wifiSSID = "YourWiFiSSID";
+      wifiPassword = "YourWiFiPassword";
+      printerUri = "ipp://user:pass@10.30.30.66/ipp";
+      printerMac = "AA:BB:CC:DD:EE:FF";
+    };
+  };
+}


### PR DESCRIPTION
# Summary

  - Add declarative NixOS configuration for deploying the print bot to a Raspberry Pi 4 using Colmena
  - Add a proper NixOS service module with systemd hardening (dedicated user, ProtectSystem, PrivateTmp, etc.)
  - Add Nix package derivation that builds the Rust bot via rustPlatform.buildRustPackage
  - Add README with project overview and deployment instructions

# What's included

  - nix/flake.nix — Flake with colmena and nixosConfigurations outputs (including a QEMU VM for testing)
  - nix/hive.nix — Colmena hive configuration that injects secrets (bot token, WiFi, printer URI, SSH key, printer MAC) from a gitignored secrets.nix
  - nix/hosts/rpi4.nix — RPi4 host config: boot, networking (WiFi + static ethernet), CUPS, dnsmasq DHCP server, Tailscale, SSH (key-only)
  - nix/modules/print-bot.nix — NixOS module with services.print-bot options
  - nix/pkgs/print-bot.nix — Rust package derivation

# Infrastructure

  - WiFi via wpa_supplicant, Tailscale for remote access
  - Ethernet direct link to HP LaserJet M207 with dnsmasq DHCP server assigning a static lease
  - CUPS configured declaratively via hardware.printers
  - All secrets (bot token, WiFi password, printer credentials, SSH key) managed via gitignored nix/secrets/secrets.nix
